### PR TITLE
Fix test coverage on Code Climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ before_script:
   - ./cc-test-reporter before-build
 script:
   - npm test
+  - cat ./coverage/lcov.info
 after_success:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build --debug -t lcov --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
Code Climate is not receiving test coverage reports from Travis CI builds.

# SOLUTION / EXPLANATION
- https://github.com/codeclimate/test-reporter/issues/346#issuecomment-405837442